### PR TITLE
[Phase 6] Documentation & Portfolio Polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,108 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-03-22
+
+### Added
+
+- Executive README with architecture diagram, configuration table, and tech stack
+- CHANGELOG.md following Keep a Changelog format
+- Usage guide (`docs/usage-guide.md`) covering demo, custom queries, HITL, and dashboard
+- Troubleshooting guide (`docs/troubleshooting.md`) with common errors and solutions
+- `web_search` tool section in tools reference documentation
+- Version badge in README
+
+### Changed
+
+- README rewritten as portfolio landing page with highlights, quick start, and documentation index
+- Tools reference updated from 6 to 7 tools (added `web_search` section)
+- Example prompts in tools reference translated from Portuguese to English
+- Version bumped to 1.0.0
+
+## [0.5.0] - 2026-03-22
+
+### Added
+
+- Unit tests for report generator (`test_report_generator.py`, 15 tests)
+- Unit tests for LangSmith helpers (`test_langsmith.py`, 6 tests)
+- Edge case tests for tools (`test_edge_tools.py`, 8 tests)
+- Edge case tests for analysis modules (`test_edge_analysis.py`, 6 tests)
+- Integration tests against real MLflow (`test_agent_e2e.py`, 5 tests)
+- Integration test fixtures (`conftest.py` with `seeded_experiment`)
+- 75% coverage threshold enforced in CI
+
+### Changed
+
+- Total test count increased from 98 to 124
+- Code coverage increased to 83.68%
+- CI workflow updated to run edge case tests and enforce coverage threshold
+
+## [0.4.0] - 2026-03-22
+
+### Added
+
+- `GovernanceCallbackHandler` for structured JSONL tracing of every agent action
+- Token budget enforcement (`AGENT_MAX_TOKENS`)
+- Execution timeout via `ThreadPoolExecutor` (Windows-compatible)
+- Consecutive failure threshold (`AGENT_MAX_FAILURES`)
+- `invoke_with_governance()` wrapper in agent builder
+- Human-in-the-Loop (HITL) support via `interrupt_on` parameter
+- HITL demo script (`scripts/run_demo_hitl.py`)
+- Streamlit governance dashboard with Run Explorer and Tool Analytics pages
+- JSONL log reader utility (`src/dashboard/log_reader.py`)
+- Governance documentation (`docs/governance.md`)
+- HITL documentation (`docs/hitl.md`)
+
+### Changed
+
+- Agent builder updated to support HITL tools and governance callbacks
+- Agent config extended with governance fields
+- Demo script updated to use `invoke_with_governance()`
+- Observability docs updated with JSONL tracing and dashboard sections
+
+## [0.3.0] - 2026-03-17
+
+### Added
+
+- Agent builder (`src/agent/builder.py`) with `create_analyst_agent()` factory
+- Agent configuration via environment variables (`src/agent/config.py`)
+- Engineered system prompt (`src/agent/prompts/system_prompt.md`)
+- Demo script (`scripts/run_demo.py`) with 3 demonstration queries
+- LangSmith observability helpers (`src/observability/langsmith.py`)
+- Architecture decision records (`docs/architecture-decisions.md`)
+- Setup guide (`docs/SETUP.md`)
+
+### Changed
+
+- Project structure reorganized with `agent/` and `observability/` modules
+
+## [0.2.0] - 2026-03-16
+
+### Added
+
+- `load_experiment` tool — load experiment metadata and runs from MLflow
+- `compare_runs` tool — side-by-side metric comparison table
+- `diagnose_run` tool — overfitting detection with severity levels
+- `analyze_patterns` tool — hyperparameter-metric correlation analysis
+- `suggest_next_experiments` tool — generate next-run configurations
+- `generate_report` tool — full Markdown report saved to disk
+- `web_search` tool — optional Tavily-powered web search
+- Tools reference documentation (`docs/tools-reference.md`)
+- Markdown report generator (`src/report/generator.py`)
+- Analysis modules: metrics, overfitting, patterns, suggestions
+
+## [0.1.0] - 2026-03-15
+
+### Added
+
+- Project scaffolding with `pyproject.toml` and development dependencies
+- MLflow client wrapper (`src/mlflow_client/client.py`) with typed models
+- Docker Compose stack for MLflow + PostgreSQL + MinIO
+- Demo experiment seeder (`scripts/seed_mlflow.py`)
+- CI pipeline with ruff, mypy, and pytest
+- Contributing guidelines and branch naming conventions
+- MIT license

--- a/README.md
+++ b/README.md
@@ -4,24 +4,68 @@
 [![codecov](https://codecov.io/gh/brunoramosmartins/ml-experiment-analyst-agent/branch/main/graph/badge.svg)](https://codecov.io/gh/brunoramosmartins/ml-experiment-analyst-agent)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Version](https://img.shields.io/badge/version-1.0.0-green.svg)](CHANGELOG.md)
 
 > An autonomous agent that reads, compares, and interprets machine learning experiments — detecting patterns, identifying problems, and proposing next steps. Like a senior ML engineer who never sleeps.
 
 ---
 
-## What is this?
+## Demo
 
-Any mature ML pipeline accumulates dozens or hundreds of runs in MLflow. Manually navigating those runs to extract insights is slow, prone to confirmation bias, and does not scale.
+<!-- TODO: Record demo GIF with asciinema or screen capture tool.
+     Run: python scripts/run_demo.py
+     Show the agent analyzing an experiment and generating a report. -->
 
-This agent takes a natural language query, connects to a MLflow Tracking Server, and autonomously produces a structured analysis report — covering metric comparisons, overfitting diagnostics, hyperparameter pattern analysis, and next-experiment suggestions.
-
-**Stack:** Python · [deepagents](https://pypi.org/project/deepagents/) (LangGraph) · MLflow · LangSmith · Llama 3.1 via [Ollama](https://ollama.com/) *(swappable to any LangChain-compatible LLM)*
+*Demo GIF coming soon — see [Quick Start](#quick-start) to try it yourself.*
 
 ---
 
-## Demo
+## Highlights
 
-> *Demo GIF coming in Phase 6 (Portfolio Polish)*
+- **Autonomous ML analysis** — Point the agent at any MLflow experiment and get a structured analysis report with zero manual work
+- **Overfitting detection** — Automatically identifies train/val gaps with severity levels (LOW, MEDIUM, HIGH) across all runs
+- **Hyperparameter pattern discovery** — Correlates numeric parameters with target metrics to find what drives performance
+- **Next-experiment suggestions** — Generates concrete configurations with justifications and testable hypotheses
+- **Built-in governance** — Token budgets, execution timeouts, failure thresholds, and full JSONL tracing of every agent action
+- **Human-in-the-Loop** — Optionally pause the agent before critical tools for human approval, editing, or rejection
+
+---
+
+## Architecture
+
+```
+User Query (natural language)
+    |
+    v
++---------------------------------------------------+
+|  ML Experiment Analyst Agent                      |
+|  (deepagents / LangGraph)                         |
+|                                                   |
+|  Tools:                                           |
+|  +-- load_experiment    --> MLflow Tracking Server |
+|  +-- compare_runs       --> MLflow Tracking Server |
+|  +-- diagnose_run       --> analysis/overfitting   |
+|  +-- analyze_patterns   --> analysis/patterns      |
+|  +-- suggest_next       --> analysis/suggestions   |
+|  +-- generate_report    --> data/agent-workspace/  |
+|  +-- web_search         --> Tavily API (optional)  |
++---------------------------------------------------+
+    |                          |
+    v                          v
++------------------+   +----------------------------+
+| Governance Layer |   | Observability              |
+| JSONL traces     |   | LangSmith (cloud tracing)  |
+| Token budgets    |   +----------------------------+
+| Failure limits   |
+| Exec timeouts    |
++------------------+
+    |
+    v
++----------------------------+
+| Streamlit Dashboard        |
+| Run Explorer + Tool Stats  |
++----------------------------+
+```
 
 ---
 
@@ -31,7 +75,9 @@ This agent takes a natural language query, connects to a MLflow Tracking Server,
 # 1. Clone and install
 git clone https://github.com/brunoramosmartins/ml-experiment-analyst-agent
 cd ml-experiment-analyst-agent
-python -m venv .venv && source .venv/bin/activate
+python -m venv .venv
+source .venv/bin/activate        # Linux / macOS
+# .venv\Scripts\activate         # Windows
 pip install -e ".[dev]"
 
 # 2. Install and start Ollama (https://ollama.com/)
@@ -39,53 +85,58 @@ ollama pull llama3.1:8b
 
 # 3. Configure environment
 cp .env.example .env
-# Fill in LANGCHAIN_API_KEY and TAVILY_API_KEY
-# LLM_PROVIDER=ollama is the default — no API key needed for local inference
+# Edit .env — LLM_PROVIDER=ollama works out of the box (no API key needed)
+# Optionally fill in LANGCHAIN_API_KEY and TAVILY_API_KEY
 
 # 4. Start MLflow (Docker required)
-make mlflow-up
+docker compose up -d
 
-# 5. Seed demo experiments
-make seed-mlflow
+# 5. Seed demo experiments (3 synthetic experiments with 29 runs)
+python scripts/seed_mlflow.py
 
 # 6. Run the demo
-make run-demo
+python scripts/run_demo.py
 ```
 
----
-
-## Architecture
-
-```
-User Query
-    │
-    ▼
-ML Experiment Analyst Agent (deepagents / LangGraph)
-    │
-    ├── load_experiment   ──► MLflow Tracking Server
-    ├── compare_runs      ──► MLflow Tracking Server
-    ├── diagnose_run      ──► src/analysis/overfitting.py
-    ├── analyze_patterns  ──► src/analysis/patterns.py
-    ├── suggest_next      ──► src/analysis/suggestions.py
-    └── generate_report   ──► data/agent-workspace/reports/
-    │
-    ├── GovernanceCallbackHandler ──► data/logs/agent_traces/ (JSONL)
-    └── LangSmith                 ──► Full execution traces
-```
+Reports are saved to `data/agent-workspace/reports/`.
 
 ---
 
 ## Agent Tools
 
-| Tool | What it does | When to use |
+| Tool | What it does | When the agent uses it |
 |---|---|---|
 | `load_experiment` | Loads experiment metadata and all runs from MLflow | Start of every analysis |
-| `compare_runs` | Side-by-side Markdown table of runs × metrics | Identify the best configuration |
-| `diagnose_run` | Overfitting detection, metric gap analysis | Understand *why* a run performed as it did |
+| `compare_runs` | Side-by-side Markdown table of runs x metrics | Identify the best configuration |
+| `diagnose_run` | Overfitting detection, metric gap analysis | Understand *why* a run underperformed |
 | `analyze_patterns` | Correlation between hyperparameters and metrics | Find which parameters matter most |
 | `suggest_next_experiments` | Concrete next-run configurations with justification | Plan the next iteration |
 | `generate_report` | Full Markdown report saved to disk | Final deliverable |
 | `web_search` | Search the web for ML techniques and papers (optional) | When external context is needed |
+
+See [Tools Reference](docs/tools-reference.md) for full signatures, parameters, and error handling.
+
+---
+
+## Configuration
+
+All settings are environment-driven via `.env` (see [`.env.example`](.env.example)):
+
+| Variable | Default | Description |
+|---|---|---|
+| `LLM_PROVIDER` | `ollama` | LLM backend: `ollama` (local, free) or `anthropic` |
+| `LLM_MODEL` | `llama3.1:8b` | Model name (must support tool calling) |
+| `OLLAMA_BASE_URL` | `http://localhost:11434` | Ollama server URL |
+| `ANTHROPIC_API_KEY` | — | Required only when `LLM_PROVIDER=anthropic` |
+| `LANGCHAIN_API_KEY` | — | LangSmith API key (optional, enables cloud tracing) |
+| `LANGCHAIN_TRACING_V2` | `true` | Enable/disable LangSmith tracing |
+| `TAVILY_API_KEY` | — | Tavily API key (optional, enables web search tool) |
+| `MLFLOW_TRACKING_URI` | `http://localhost:5000` | MLflow tracking server URL |
+| `AGENT_WORKSPACE_PATH` | `data/agent-workspace` | Output directory for reports |
+| `AGENT_MAX_TOKENS` | `50000` | Max tokens per agent invocation |
+| `AGENT_TIMEOUT_SECONDS` | `300` | Execution timeout (seconds) |
+| `AGENT_MAX_FAILURES` | `3` | Max consecutive tool failures before abort |
+| `AGENT_TRACE_LOG_DIR` | `data/logs/agent_traces` | Directory for JSONL governance traces |
 
 ---
 
@@ -93,35 +144,62 @@ ML Experiment Analyst Agent (deepagents / LangGraph)
 
 ```
 src/
-├── agent/          # Agent builder, config, system prompt
-├── tools/          # 7 custom LangChain tools (6 core + web search)
-├── mlflow_client/  # MLflow access layer
-├── analysis/       # Pure analysis functions (metrics, overfitting, patterns)
-├── report/         # Markdown report generator
-├── observability/  # GovernanceCallbackHandler + LangSmith helpers
-└── dashboard/      # Streamlit governance dashboard
++-- agent/            # Agent builder, config, system prompt
++-- tools/            # 7 custom LangChain tools (6 core + web search)
++-- mlflow_client/    # MLflow access layer (client + models)
++-- analysis/         # Pure analysis functions (metrics, overfitting, patterns)
++-- report/           # Markdown report generator + templates
++-- observability/    # GovernanceCallbackHandler + LangSmith helpers
++-- dashboard/        # Streamlit governance dashboard
 
 tests/
-├── unit/           # Unit tests (mocked MLflow)
-├── integration/    # E2E tests against real MLflow
-└── edge_cases/     # Edge case scenarios
++-- unit/             # Unit tests (mocked MLflow)
++-- integration/      # E2E tests against real MLflow
++-- edge_cases/       # Edge case scenarios
 
 scripts/
-├── seed_mlflow.py      # Populate MLflow with 3 synthetic experiments
-├── run_demo.py         # Run 3 demonstration queries with governance
-└── run_demo_hitl.py    # Human-in-the-loop demo
++-- seed_mlflow.py        # Populate MLflow with 3 synthetic experiments
++-- run_demo.py           # Run 3 demonstration queries with governance
++-- run_demo_hitl.py      # Human-in-the-loop demo
+
+docs/                 # Architecture decisions, setup, tools reference, guides
 ```
 
 ---
 
-## References
+## Documentation
 
-- [Architecture Decision Records](docs/architecture-decisions.md)
-- [Setup Guide](docs/SETUP.md)
-- [Tools Reference](docs/tools-reference.md)
-- [Governance & Observability](docs/governance.md)
-- [Human-in-the-Loop](docs/hitl.md)
-- [Prompt Engineering Log](docs/prompt-engineering-log.md)
-- [Demo Experiments](docs/demo-experiments.md)
-- [Contributing](CONTRIBUTING.md)
-- [deepagents](https://pypi.org/project/deepagents/) · [LangSmith](https://smith.langchain.com/) · [MLflow](https://mlflow.org/)
+| Document | Description |
+|---|---|
+| [Setup Guide](docs/SETUP.md) | Step-by-step installation and infrastructure setup |
+| [Usage Guide](docs/usage-guide.md) | How to run the agent, customize queries, use HITL mode |
+| [Tools Reference](docs/tools-reference.md) | Full API reference for all 7 tools |
+| [Governance & Observability](docs/governance.md) | JSONL tracing, token budgets, execution limits |
+| [Human-in-the-Loop](docs/hitl.md) | Pause agent before critical tools for human review |
+| [Troubleshooting](docs/troubleshooting.md) | Common errors and solutions |
+| [Architecture Decisions](docs/architecture-decisions.md) | ADRs: framework, LLM, backend, observability choices |
+| [Demo Experiments](docs/demo-experiments.md) | Description of the 3 synthetic MLflow experiments |
+| [Prompt Engineering Log](docs/prompt-engineering-log.md) | System prompt iteration history |
+| [Contributing](CONTRIBUTING.md) | Branch naming, commit conventions, PR workflow |
+| [Changelog](CHANGELOG.md) | Version history following Keep a Changelog |
+
+---
+
+## Tech Stack
+
+| Component | Technology |
+|---|---|
+| Agent framework | [deepagents](https://pypi.org/project/deepagents/) (LangGraph) |
+| LLM (local) | [Ollama](https://ollama.com/) + Llama 3.1 |
+| LLM (cloud) | [Anthropic](https://www.anthropic.com/) Claude (swappable) |
+| Experiment tracking | [MLflow](https://mlflow.org/) |
+| Cloud observability | [LangSmith](https://smith.langchain.com/) |
+| Web search | [Tavily](https://tavily.com/) |
+| Dashboard | [Streamlit](https://streamlit.io/) |
+| CI/CD | GitHub Actions (lint, typecheck, test with 75% coverage) |
+
+---
+
+## License
+
+[MIT](LICENSE) - Bruno Ramos Martins

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -1,7 +1,11 @@
 # Tools Reference
 
-This document describes all 6 custom LangChain tools available to the ML Experiment Analyst Agent.
+This document describes all 7 custom LangChain tools available to the ML Experiment Analyst Agent.
 Each tool is a `@tool`-decorated function in `src/tools/` and is registered in `src/tools/__init__.py`.
+
+> **Governance note:** When using `invoke_with_governance()`, all tool invocations are automatically
+> traced by the `GovernanceCallbackHandler`. Each call is logged as a JSONL event with tool name,
+> input/output summaries, duration, and token usage. See [Governance](governance.md) for details.
 
 ---
 
@@ -15,6 +19,7 @@ Each tool is a `@tool`-decorated function in `src/tools/` and is registered in `
 | [`analyze_patterns`](#analyze_patterns) | Correlate hyperparameters with a target metric | Step 4 |
 | [`suggest_next_experiments`](#suggest_next_experiments) | Generate next-experiment configurations | Step 5 |
 | [`generate_report`](#generate_report) | Produce and save a full Markdown analysis report | Step 6 (final) |
+| [`web_search`](#web_search) | Search the web for ML techniques and papers | On demand (optional) |
 
 ---
 
@@ -64,7 +69,7 @@ A formatted string containing:
 ### Example agent prompt
 
 ```
-"Analise o experimento binary-classification"
+"Analyze the binary-classification experiment"
 → Agent calls: load_experiment(experiment_name="binary-classification")
 ```
 
@@ -112,7 +117,7 @@ A formatted string containing:
 ### Example agent prompt
 
 ```
-"Compare os 3 melhores runs do experimento"
+"Compare the top 3 runs of the experiment"
 → Agent calls: compare_runs(run_ids=["abc123", "def456", "ghi789"])
 ```
 
@@ -167,7 +172,7 @@ A formatted string containing:
 ### Example agent prompt
 
 ```
-"Por que o run abc123 teve performance baixa?"
+"Why did run abc123 perform poorly?"
 → Agent calls: diagnose_run(run_id="abc123...")
 ```
 
@@ -220,7 +225,7 @@ A formatted string containing:
 ### Example agent prompt
 
 ```
-"Quais hiperparâmetros mais impactam val_accuracy?"
+"Which hyperparameters have the most impact on val_accuracy?"
 → Agent calls: analyze_patterns(experiment_name="binary-classification", target_metric="val_accuracy")
 ```
 
@@ -274,7 +279,7 @@ Numbered suggestions (up to `num_suggestions`), each with:
 ### Example agent prompt
 
 ```
-"Quais experimentos devo rodar a seguir para melhorar val_loss?"
+"What experiments should I run next to improve val_loss?"
 → Agent calls: suggest_next_experiments(experiment_name="regression-v2", optimization_goal="minimize val_loss")
 ```
 
@@ -338,9 +343,60 @@ The generated Markdown file includes:
 ### Example agent prompt
 
 ```
-"Gera um relatório completo do experimento binary-classification"
+"Generate a full report for the binary-classification experiment"
 → Agent calls: generate_report(experiment_name="binary-classification", report_title="Binary Classification Analysis - March 2026")
 ```
+
+---
+
+## `web_search`
+
+**File:** `src/tools/web_search.py`
+
+**Purpose:** Searches the web for ML techniques, papers, and best practices using the Tavily API. This tool is **optional** — it is only registered when `TAVILY_API_KEY` is set in the environment.
+
+### Signature
+
+```python
+web_search(
+    query: str,
+    max_results: int = 3,
+) -> str
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `query` | `str` | required | Search query (e.g., `"gradient boosting overfitting remedies"`) |
+| `max_results` | `int` | `3` | Number of results to return (min: 1, max: 5) |
+
+### Returns
+
+A formatted string containing numbered search results, each with:
+- Title
+- URL
+- Content snippet (truncated to 300 characters)
+
+### Error cases
+
+| Condition | Return message |
+|---|---|
+| `TAVILY_API_KEY` not set | `ERROR: TAVILY_API_KEY is not configured...` |
+| `tavily-python` not installed | `ERROR: tavily-python is not installed...` |
+| API error | `ERROR: Web search failed — {details}` |
+| No results | `No results found for: {query}` |
+
+### Example agent prompt
+
+```
+"Search for best practices to reduce overfitting in gradient boosting models"
+→ Agent calls: web_search(query="gradient boosting overfitting remedies", max_results=3)
+```
+
+### Enabling web search
+
+Set `TAVILY_API_KEY` in your `.env` file. The tool is automatically registered when the key is present. Get a free API key at [app.tavily.com](https://app.tavily.com/).
 
 ---
 
@@ -356,7 +412,8 @@ from src.tools import (
     analyze_patterns,
     suggest_next_experiments,
     generate_report,
-    ALL_TOOLS,  # list of all 6 tools, for passing to create_deep_agent
+    web_search,
+    ALL_TOOLS,  # 6 core tools + web_search if TAVILY_API_KEY is set
 )
 ```
 
@@ -372,5 +429,5 @@ Or they can be registered with the agent (done automatically in `src/agent/build
 ```python
 from src.agent.builder import create_analyst_agent
 agent = create_analyst_agent()
-# Agent now has all 6 tools available
+# Agent now has all tools available
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,242 @@
+# Troubleshooting
+
+Common errors and their solutions when running the ML Experiment Analyst Agent.
+
+---
+
+## MLflow Connection Errors
+
+**Symptom:** `ERROR loading experiment: Could not connect to MLflow at http://localhost:5000`
+
+**Solutions:**
+
+1. Make sure Docker is running:
+   ```bash
+   docker compose up -d
+   ```
+
+2. Wait 10-15 seconds for the containers to initialize, then check health:
+   ```bash
+   curl http://localhost:5000/health
+   ```
+
+3. Check container logs:
+   ```bash
+   docker compose logs mlflow
+   ```
+
+4. If port 5000 is in use by another service, update `MLFLOW_TRACKING_URI` in `.env`.
+
+---
+
+## Ollama Not Responding
+
+**Symptom:** `Connection refused` or timeout when calling the agent with `LLM_PROVIDER=ollama`.
+
+**Solutions:**
+
+1. Check that Ollama is running:
+   ```bash
+   ollama list
+   ```
+
+2. If not running, start it:
+   ```bash
+   ollama serve
+   ```
+
+3. Verify the model is pulled:
+   ```bash
+   ollama pull llama3.1:8b
+   ```
+
+4. Check the base URL matches your config:
+   ```bash
+   curl http://localhost:11434/api/tags
+   ```
+
+---
+
+## Tool Calling Failures with llama3
+
+**Symptom:** Agent calls tools incorrectly or fails to use tools at all.
+
+**Cause:** `llama3:latest` (Llama 3.0) does **not** support tool calling. This is a known limitation of the base Llama 3 model.
+
+**Solution:** Use a model that supports tool calling:
+
+```env
+LLM_MODEL=llama3.1:8b     # recommended
+# or
+LLM_MODEL=llama3.2:3b     # lighter alternative
+```
+
+Then pull the model:
+```bash
+ollama pull llama3.1:8b
+```
+
+---
+
+## Tavily Web Search Not Loading
+
+**Symptom:** Only 6 tools loaded instead of 7. The `web_search` tool is missing.
+
+**Cause:** The `TAVILY_API_KEY` environment variable was not set when the tools module was imported. The key check happens at import time.
+
+**Solutions:**
+
+1. Ensure `TAVILY_API_KEY` is set in your `.env` file:
+   ```
+   TAVILY_API_KEY=tvly-your-key-here
+   ```
+
+2. Make sure `python-dotenv` is installed and `.env` is loaded before tool imports. The tool registry calls `load_dotenv()` automatically, but if you import tools before the `.env` file exists, the key will not be found.
+
+3. Verify in your script:
+   ```python
+   from src.tools import ALL_TOOLS
+   print(f"Tools loaded: {len(ALL_TOOLS)}")
+   # Should show 7 if Tavily is configured
+   ```
+
+---
+
+## Import Errors
+
+**Symptom:** `ModuleNotFoundError: No module named 'deepagents'` or similar.
+
+**Solutions:**
+
+1. Make sure you are in the virtual environment:
+   ```bash
+   source .venv/bin/activate        # Linux / macOS
+   # .venv\Scripts\activate         # Windows
+   ```
+
+2. Install the project in editable mode:
+   ```bash
+   pip install -e ".[dev]"
+   ```
+
+3. Verify the install:
+   ```bash
+   python -c "from deepagents import create_deep_agent; print('OK')"
+   ```
+
+---
+
+## MinIO Bucket Not Found
+
+**Symptom:** MLflow artifact storage errors referencing S3 or MinIO buckets.
+
+**Cause:** The `minio-init` container may have failed to create the default bucket.
+
+**Solutions:**
+
+1. Check the init container logs:
+   ```bash
+   docker compose logs minio-init
+   ```
+
+2. Restart the stack:
+   ```bash
+   docker compose down
+   docker compose up -d
+   ```
+
+3. Manually access MinIO console at `http://localhost:9001` (default credentials: `minioadmin` / `minioadmin`) and verify the bucket exists.
+
+---
+
+## GovernanceLimitError
+
+**Symptom:** `GovernanceLimitError: Token budget exceeded` or `GovernanceLimitError: Too many consecutive failures`.
+
+**Cause:** The agent hit one of the governance safety limits.
+
+**Solutions:**
+
+- **Token budget exceeded:** Increase the limit in `.env`:
+  ```
+  AGENT_MAX_TOKENS=100000
+  ```
+
+- **Consecutive failures:** The agent failed 3+ tool calls in a row. Check the JSONL trace log for details:
+  ```bash
+  ls data/logs/agent_traces/
+  ```
+  Increase the threshold if needed:
+  ```
+  AGENT_MAX_FAILURES=5
+  ```
+
+- **Root cause:** Review the trace logs to understand why tools are failing. Common causes include MLflow being down or invalid experiment names.
+
+---
+
+## TimeoutError
+
+**Symptom:** `TimeoutError` after the agent runs for the configured timeout period.
+
+**Cause:** The agent took longer than `AGENT_TIMEOUT_SECONDS` (default: 300 seconds).
+
+**Solutions:**
+
+1. Increase the timeout in `.env`:
+   ```
+   AGENT_TIMEOUT_SECONDS=600
+   ```
+
+2. Use a faster LLM model or switch to Anthropic for faster inference:
+   ```
+   LLM_PROVIDER=anthropic
+   ```
+
+3. Simplify your query. Complex queries that require many tool calls take longer.
+
+---
+
+## Dashboard Shows No Data
+
+**Symptom:** The Streamlit dashboard opens but shows empty tables and charts.
+
+**Cause:** No JSONL trace logs have been generated yet.
+
+**Solution:** Run the demo to generate trace data, then open the dashboard:
+
+```bash
+python scripts/run_demo.py
+streamlit run src/dashboard/app.py
+```
+
+The dashboard reads from the directory configured in `AGENT_TRACE_LOG_DIR` (default: `data/logs/agent_traces/`).
+
+---
+
+## Tests Failing
+
+**Symptom:** `pytest` fails with import errors or unexpected failures.
+
+**Solutions:**
+
+1. Install dev dependencies:
+   ```bash
+   pip install -e ".[dev]"
+   ```
+
+2. Run only unit tests (no MLflow required):
+   ```bash
+   python -m pytest tests/unit/ tests/edge_cases/ -v
+   ```
+
+3. Integration tests require a running MLflow server:
+   ```bash
+   docker compose up -d
+   python -m pytest tests/integration/ -v -m integration
+   ```
+
+4. Check environment variables are not interfering:
+   ```bash
+   LANGCHAIN_TRACING_V2=false python -m pytest tests/ -v
+   ```

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1,0 +1,240 @@
+# Usage Guide
+
+This guide covers how to run the ML Experiment Analyst Agent, customize queries, use Human-in-the-Loop mode, and view the governance dashboard.
+
+**Prerequisites:** Complete the [Setup Guide](SETUP.md) first.
+
+---
+
+## Table of Contents
+
+- [Running the Demo](#running-the-demo)
+- [Writing Custom Queries](#writing-custom-queries)
+- [Human-in-the-Loop Mode](#human-in-the-loop-mode)
+- [Governance Dashboard](#governance-dashboard)
+- [Using Your Own MLflow Experiments](#using-your-own-mlflow-experiments)
+- [Switching LLM Providers](#switching-llm-providers)
+- [Enabling Web Search](#enabling-web-search)
+
+---
+
+## Running the Demo
+
+The demo script runs 3 queries against the agent and generates analysis reports:
+
+```bash
+python scripts/run_demo.py
+```
+
+**What it does:**
+
+1. Analyzes the `binary-classification` experiment (full report with overfitting diagnostics)
+2. Compares the top 3 runs of `regression-v2` by `val_rmse`
+3. Analyzes the `overfit-test` experiment (identifies overfitting problems)
+
+Each query is wrapped with governance tracking. Reports are saved to `data/agent-workspace/reports/`.
+
+**Expected output:**
+
+```
+[1/3] Analyzing binary-classification experiment...
+  -> Completed in 45.2s
+[2/3] Comparing regression-v2 runs...
+  -> Completed in 32.1s
+[3/3] Analyzing overfit-test experiment...
+  -> Completed in 38.7s
+
+Summary: 3/3 queries succeeded
+Reports saved: data/agent-workspace/reports/
+```
+
+---
+
+## Writing Custom Queries
+
+You can write your own script to query the agent:
+
+```python
+from src.agent.builder import create_analyst_agent, invoke_with_governance
+from src.agent.config import AgentConfig
+
+# Create the agent (uses settings from .env)
+config = AgentConfig()
+agent = create_analyst_agent(config)
+
+# Run a query with governance tracking
+result = invoke_with_governance(
+    agent,
+    "Analyze the binary-classification experiment. Focus on which hyperparameters "
+    "drive val_accuracy and suggest 3 next experiments.",
+    config,
+)
+
+# Extract the final response
+messages = result.get("messages", [])
+if messages:
+    print(messages[-1].content)
+```
+
+**Tips for effective queries:**
+
+- Be specific about the experiment name (must match MLflow exactly)
+- Mention the target metric if you want pattern analysis (e.g., `val_accuracy`, `val_loss`)
+- Ask for reports when you want a saved Markdown file
+- The agent decides which tools to call based on your query
+
+---
+
+## Human-in-the-Loop Mode
+
+HITL mode pauses the agent before executing specific tools, allowing you to approve, edit, or reject the action.
+
+```bash
+python scripts/run_demo_hitl.py
+```
+
+**How it works:**
+
+1. The agent processes your query normally
+2. When it reaches a protected tool (e.g., `generate_report`), it pauses
+3. You see the tool name and parameters the agent wants to use
+4. You choose:
+   - `[y]es` — approve and continue
+   - `[e]dit` — modify the parameters before continuing
+   - `[n]o` — reject and let the agent try a different approach
+
+**Example interaction:**
+
+```
+Agent wants to call: generate_report
+Parameters:
+  experiment_name: binary-classification
+  report_title: Binary Classification Analysis
+
+Approve? [y]es / [e]dit / [n]o: e
+Enter new report_title: Q1 2026 Binary Classification Review
+Resuming with updated parameters...
+```
+
+**Programmatic HITL setup:**
+
+```python
+from src.agent.builder import create_analyst_agent
+
+# Protect specific tools
+agent = create_analyst_agent(hitl_tools=["generate_report", "suggest_next_experiments"])
+```
+
+See [Human-in-the-Loop documentation](hitl.md) for details.
+
+---
+
+## Governance Dashboard
+
+The Streamlit dashboard visualizes agent execution traces stored as JSONL files.
+
+```bash
+streamlit run src/dashboard/app.py
+```
+
+Open `http://localhost:8501` in your browser.
+
+**Page 1 — Run Explorer:**
+
+- List of all agent runs with date, tool calls, errors, duration, tokens
+- Click a run to see the full event timeline
+- Color-coded rows: green for successes, red for errors
+- Expandable event details with input/output summaries
+
+**Page 2 — Tool Analytics:**
+
+- Call frequency per tool (bar chart)
+- Average latency per tool (bar chart)
+- Detailed table with call count, avg/p95 latency, error count, error rate
+
+**Note:** The dashboard reads from `data/logs/agent_traces/`. Run the demo first to generate trace data.
+
+---
+
+## Using Your Own MLflow Experiments
+
+To analyze experiments from your own MLflow server:
+
+1. Update `MLFLOW_TRACKING_URI` in `.env` to point to your server:
+
+   ```
+   MLFLOW_TRACKING_URI=http://your-mlflow-server:5000
+   ```
+
+2. If your server uses S3 artifacts, update the S3 credentials:
+
+   ```
+   MLFLOW_S3_ENDPOINT_URL=https://s3.amazonaws.com
+   AWS_ACCESS_KEY_ID=your-key
+   AWS_SECRET_ACCESS_KEY=your-secret
+   ```
+
+3. Run the agent with your experiment name:
+
+   ```python
+   result = invoke_with_governance(
+       agent,
+       "Analyze the my-custom-experiment experiment and generate a full report.",
+       config,
+   )
+   ```
+
+The agent works with any MLflow experiment that has logged metrics and parameters.
+
+---
+
+## Switching LLM Providers
+
+### Ollama (default, local, free)
+
+```env
+LLM_PROVIDER=ollama
+LLM_MODEL=llama3.1:8b
+OLLAMA_BASE_URL=http://localhost:11434
+```
+
+Make sure Ollama is running and the model is pulled:
+
+```bash
+ollama pull llama3.1:8b
+ollama serve  # if not already running
+```
+
+**Compatible models** (must support tool calling):
+- `llama3.1:8b` (recommended)
+- `llama3.2:3b` (lighter, still supports tools)
+- `llama3:latest` does **NOT** support tool calling
+
+### Anthropic (cloud, paid)
+
+```env
+LLM_PROVIDER=anthropic
+LLM_MODEL=claude-sonnet-4-5-20250929
+ANTHROPIC_API_KEY=sk-ant-your-key-here
+```
+
+Anthropic models are faster and more capable but require an API key and incur costs.
+
+---
+
+## Enabling Web Search
+
+The `web_search` tool uses the Tavily API to search the web for ML techniques and papers. It is optional and disabled by default.
+
+To enable:
+
+1. Get an API key at [app.tavily.com](https://app.tavily.com/)
+2. Add it to your `.env`:
+
+   ```
+   TAVILY_API_KEY=tvly-your-key-here
+   ```
+
+3. Restart the agent. The tool is automatically registered when the key is present.
+
+When enabled, the agent can search for external context about model architectures, hyperparameter tuning strategies, or ML best practices to enrich its analysis.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ml-experiment-analyst-agent"
-version = "0.5.0"
+version = "1.0.0"
 description = "An autonomous ML experiment analysis agent built with deepagents + LangGraph"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary
- README rewritten as portfolio landing page with highlights, architecture diagram, config table, tech stack, and full documentation index
- CHANGELOG.md added with Keep a Changelog format covering all 6 phases (v0.1.0 through v1.0.0)
- Usage guide created (docs/usage-guide.md) covering demo, custom queries, HITL mode, governance dashboard, LLM switching, and web search
- Troubleshooting guide created (docs/troubleshooting.md) with 10 common issues and solutions
- Tools reference updated with web_search section, English examples, and governance note
- Version bumped to 1.0.0

## Test plan
- [x] ruff check passes
- [x] 124 tests passing
- [x] 83.68% coverage (above 75% threshold)
- [ ] Verify all documentation links work from README
- [ ] Review rendered Markdown on GitHub