### PR TITLE
fix: governance observability and multi-provider LLM support

### DIFF
--- a/src/agent/builder.py
+++ b/src/agent/builder.py
@@ -42,9 +42,17 @@ def _build_llm(config: AgentConfig) -> BaseChatModel:
             temperature=config.temperature,
             max_tokens=config.max_tokens,
         )
+    if config.llm_provider == "openai":
+        from langchain_openai import ChatOpenAI
+
+        return ChatOpenAI(
+            model=config.llm_model,
+            temperature=config.temperature,
+            max_tokens=config.max_tokens,
+        )
     raise ValueError(
         f"Unsupported LLM provider: {config.llm_provider!r}. "
-        "Supported values: 'ollama', 'anthropic'."
+        "Supported values: 'ollama', 'anthropic', 'openai'."
     )
 
 
@@ -95,16 +103,14 @@ def create_analyst_agent(
     system_prompt = _load_system_prompt()
     backend = FilesystemBackend(root_dir=config.workspace_path)
 
-    interrupt_on = (
-        {name: True for name in hitl_tools} if hitl_tools else None
-    )
+    interrupt_on = {name: True for name in hitl_tools} if hitl_tools else None
 
     agent = create_deep_agent(
         model=llm,
         tools=ALL_TOOLS,
         system_prompt=system_prompt,
         backend=backend,
-        interrupt_on=interrupt_on,
+        interrupt_on=interrupt_on,  # type: ignore[arg-type]
     )
 
     logger.info(
@@ -156,7 +162,11 @@ def invoke_with_governance(
     )
 
     invoke_input = {"messages": [{"role": "user", "content": message}]}
-    invoke_config = {"callbacks": [handler]}
+    invoke_config: dict[str, Any] = {
+        "callbacks": [handler],
+        "run_name": f"analyst-agent-{run_id}",
+        "metadata": {"run_id": run_id, "query_preview": message[:100]},
+    }
 
     with ThreadPoolExecutor(max_workers=1) as pool:
         future = pool.submit(agent.invoke, invoke_input, invoke_config)
@@ -169,8 +179,7 @@ def invoke_with_governance(
                 run_id,
             )
             raise TimeoutError(
-                f"Agent execution timed out after "
-                f"{config.execution_timeout_seconds}s"
+                f"Agent execution timed out after {config.execution_timeout_seconds}s"
             ) from None
 
     logger.info(

--- a/src/agent/config.py
+++ b/src/agent/config.py
@@ -14,12 +14,8 @@ class AgentConfig:
     """
 
     # ─── LLM ──────────────────────────────────────────────────────────────────
-    llm_provider: str = field(
-        default_factory=lambda: os.getenv("LLM_PROVIDER", "ollama")
-    )
-    llm_model: str = field(
-        default_factory=lambda: os.getenv("LLM_MODEL", "llama3.1:8b")
-    )
+    llm_provider: str = field(default_factory=lambda: os.getenv("LLM_PROVIDER", "ollama"))
+    llm_model: str = field(default_factory=lambda: os.getenv("LLM_MODEL", "llama3.1:8b"))
     ollama_base_url: str = field(
         default_factory=lambda: os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
     )
@@ -28,9 +24,7 @@ class AgentConfig:
 
     # ─── Filesystem backend ───────────────────────────────────────────────────
     workspace_path: Path = field(
-        default_factory=lambda: Path(
-            os.getenv("AGENT_WORKSPACE_PATH", "data/agent-workspace")
-        )
+        default_factory=lambda: Path(os.getenv("AGENT_WORKSPACE_PATH", "data/agent-workspace"))
     )
 
     # ─── MLflow ───────────────────────────────────────────────────────────────
@@ -49,7 +43,5 @@ class AgentConfig:
         default_factory=lambda: int(os.getenv("AGENT_MAX_FAILURES", "3"))
     )
     trace_log_dir: Path = field(
-        default_factory=lambda: Path(
-            os.getenv("AGENT_TRACE_LOG_DIR", "data/logs/agent_traces")
-        )
+        default_factory=lambda: Path(os.getenv("AGENT_TRACE_LOG_DIR", "data/logs/agent_traces"))
     )

--- a/src/analysis/metrics.py
+++ b/src/analysis/metrics.py
@@ -55,9 +55,7 @@ def rank_runs(
         ValueError: If the metric column does not exist in the DataFrame.
     """
     if metric not in df.columns:
-        raise ValueError(
-            f"Metric '{metric}' not found. Available: {list(df.columns)}"
-        )
+        raise ValueError(f"Metric '{metric}' not found. Available: {list(df.columns)}")
     return df.sort_values(metric, ascending=ascending, na_position="last")
 
 

--- a/src/analysis/overfitting.py
+++ b/src/analysis/overfitting.py
@@ -19,6 +19,7 @@ else:
     class StrEnum(str, Enum):  # type: ignore[no-redef]  # noqa: UP042
         """Backport for Python < 3.11."""
 
+
 from src.mlflow_client.models import RunDetails
 
 # Metrics where *lower* values are better (gap = val − train)
@@ -27,9 +28,9 @@ _LOWER_IS_BETTER = {"loss", "rmse", "mae", "mse", "error"}
 
 class OverfitSeverity(StrEnum):
     NONE = "none"
-    LOW = "low"        # 0.05 ≤ gap < 0.10
+    LOW = "low"  # 0.05 ≤ gap < 0.10
     MEDIUM = "medium"  # 0.10 ≤ gap < 0.20
-    HIGH = "high"      # gap ≥ 0.20
+    HIGH = "high"  # gap ≥ 0.20
 
 
 @dataclass
@@ -156,6 +157,7 @@ def detect_overfitting_trend(
 
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
+
 
 def _gap_to_severity(gap: float, threshold: float) -> OverfitSeverity:
     if gap < threshold:

--- a/src/analysis/patterns.py
+++ b/src/analysis/patterns.py
@@ -19,8 +19,8 @@ class ParamCorrelation:
 
     param: str
     correlation: float  # Pearson r ∈ [-1, 1]
-    direction: str      # "positive" | "negative" | "neutral"
-    n_runs: int         # Number of runs used (non-null pairs)
+    direction: str  # "positive" | "negative" | "neutral"
+    n_runs: int  # Number of runs used (non-null pairs)
 
 
 @dataclass
@@ -62,8 +62,7 @@ def correlate_params_metrics(
             experiment_id=experiment_id,
             n_runs=len(runs),
             message=(
-                f"Not enough runs for correlation analysis "
-                f"(need {min_runs}, got {len(runs)})."
+                f"Not enough runs for correlation analysis (need {min_runs}, got {len(runs)})."
             ),
         )
 

--- a/src/analysis/suggestions.py
+++ b/src/analysis/suggestions.py
@@ -20,10 +20,10 @@ class ExperimentSuggestion:
     """A concrete suggestion for the next experiment run."""
 
     title: str
-    params: dict[str, str]     # Suggested parameter values
-    justification: str          # Why this configuration is suggested
-    hypothesis: str             # What we expect to learn from this run
-    priority: int = 1           # 1 = highest priority
+    params: dict[str, str]  # Suggested parameter values
+    justification: str  # Why this configuration is suggested
+    hypothesis: str  # What we expect to learn from this run
+    priority: int = 1  # 1 = highest priority
 
 
 @dataclass
@@ -94,9 +94,7 @@ def suggest_next_experiments(
     # ── Suggestion 2: based on top positive correlation ───────────────────────
     report = analysis.correlation_report
     if report and report.top_params:
-        top = next(
-            (p for p in report.top_params if p.direction == "positive"), None
-        )
+        top = next((p for p in report.top_params if p.direction == "positive"), None)
         if top:
             suggestions.append(
                 ExperimentSuggestion(
@@ -117,9 +115,7 @@ def suggest_next_experiments(
 
     # ── Suggestion 3: based on top negative correlation ───────────────────────
     if report and report.top_params:
-        top_neg = next(
-            (p for p in report.top_params if p.direction == "negative"), None
-        )
+        top_neg = next((p for p in report.top_params if p.direction == "negative"), None)
         if top_neg:
             suggestions.append(
                 ExperimentSuggestion(

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -37,12 +37,9 @@ if page == "Run Explorer":
     runs_df = list_runs(LOG_DIR)
 
     if runs_df.empty:
-        st.info(
-            "No trace logs found. Run the agent with governance enabled to "
-            "generate logs."
-        )
+        st.info("No trace logs found. Run the agent with governance enabled to generate logs.")
         st.code(
-            "python -c \"\n"
+            'python -c "\n'
             "from src.agent.builder import create_analyst_agent, "
             "invoke_with_governance\\n"
             "agent = create_analyst_agent()\\n"
@@ -52,6 +49,10 @@ if page == "Run Explorer":
         )
         st.stop()
 
+    # Sort by start_time descending (most recent first)
+    if "start_time" in runs_df.columns:
+        runs_df = runs_df.sort_values("start_time", ascending=False).reset_index(drop=True)
+
     st.metric("Total Runs", len(runs_df))
 
     # Run list
@@ -60,6 +61,7 @@ if page == "Run Explorer":
         [
             "run_id",
             "date",
+            "start_time",
             "n_tool_calls",
             "n_errors",
             "total_duration_ms",
@@ -69,6 +71,7 @@ if page == "Run Explorer":
     display_df.columns = [
         "Run ID",
         "Date",
+        "Started At",
         "Tool Calls",
         "Errors",
         "Duration (ms)",
@@ -81,6 +84,7 @@ if page == "Run Explorer":
     selected_run = st.selectbox(
         "Select a run to inspect",
         runs_df["run_id"].tolist(),
+        format_func=lambda rid: f"{rid} ({runs_df.loc[runs_df['run_id'] == rid, 'start_time'].iloc[0]})",
     )
 
     if selected_run:
@@ -92,12 +96,8 @@ if page == "Run Explorer":
             if not events_df.empty:
                 # Summary metrics
                 col1, col2, col3 = st.columns(3)
-                tool_events = events_df[
-                    events_df["event_type"].isin(["tool_start", "tool_end"])
-                ]
-                error_events = events_df[
-                    events_df["event_type"] == "tool_error"
-                ]
+                tool_events = events_df[events_df["event_type"].isin(["tool_start", "tool_end"])]
+                error_events = events_df[events_df["event_type"] == "tool_error"]
                 col1.metric("Tool Calls", len(tool_events) // 2)
                 col2.metric("Errors", len(error_events))
 
@@ -179,9 +179,7 @@ elif page == "Tool Analytics":
     col1.metric("Total Runs", len(runs_df))
     col2.metric("Total Tool Calls", int(analytics_df["call_count"].sum()))
     total_errors = int(analytics_df["error_count"].sum())
-    total_calls = int(
-        analytics_df["call_count"].sum() + analytics_df["error_count"].sum()
-    )
+    total_calls = int(analytics_df["call_count"].sum() + analytics_df["error_count"].sum())
     col3.metric(
         "Overall Error Rate",
         f"{total_errors / total_calls:.1%}" if total_calls > 0 else "0%",
@@ -208,6 +206,4 @@ elif page == "Tool Analytics":
         "Errors",
         "Error Rate",
     ]
-    st.dataframe(
-        display_analytics, use_container_width=True, hide_index=True
-    )
+    st.dataframe(display_analytics, use_container_width=True, hide_index=True)

--- a/src/dashboard/log_reader.py
+++ b/src/dashboard/log_reader.py
@@ -76,12 +76,12 @@ def list_runs(log_dir: Path) -> pd.DataFrame:
         date_str = jsonl_path.parent.name
         run_id = jsonl_path.stem
         tool_ends = [e for e in events if e.get("event_type") == "tool_end"]
-        tool_errors = [
-            e for e in events if e.get("event_type") == "tool_error"
-        ]
-        total_duration = sum(
-            e.get("duration_ms", 0) or 0 for e in tool_ends
-        )
+        tool_errors = [e for e in events if e.get("event_type") == "tool_error"]
+        # Use max chain_end duration as total run time (outermost chain)
+        chain_ends = [e for e in events if e.get("event_type") == "chain_end"]
+        chain_durations = [e.get("duration_ms", 0) or 0 for e in chain_ends]
+        tool_duration = sum(e.get("duration_ms", 0) or 0 for e in tool_ends)
+        total_duration = max(chain_durations) if chain_durations else tool_duration
         total_tokens = 0
         for e in events:
             tok = e.get("tokens")
@@ -145,9 +145,7 @@ def compute_tool_analytics(log_dir: Path) -> pd.DataFrame:
         return pd.DataFrame(columns=_ANALYTICS_COLUMNS)
 
     tool_ends = [e for e in all_events if e.get("event_type") == "tool_end"]
-    tool_errors = [
-        e for e in all_events if e.get("event_type") == "tool_error"
-    ]
+    tool_errors = [e for e in all_events if e.get("event_type") == "tool_error"]
 
     if not tool_ends and not tool_errors:
         return pd.DataFrame(columns=_ANALYTICS_COLUMNS)
@@ -157,7 +155,7 @@ def compute_tool_analytics(log_dir: Path) -> pd.DataFrame:
 
     # Build per-tool stats from tool_end events
     stats: list[dict] = []
-    all_tool_names = set()
+    all_tool_names: set[str] = set()
     if not df_ends.empty and "tool_name" in df_ends.columns:
         all_tool_names.update(df_ends["tool_name"].dropna().unique())
     if not df_errors.empty and "tool_name" in df_errors.columns:
@@ -189,18 +187,12 @@ def compute_tool_analytics(log_dir: Path) -> pd.DataFrame:
             {
                 "tool_name": name,
                 "call_count": call_count,
-                "avg_duration_ms": (
-                    round(durations.mean(), 1) if len(durations) > 0 else 0
-                ),
+                "avg_duration_ms": (round(durations.mean(), 1) if len(durations) > 0 else 0),
                 "p95_duration_ms": (
-                    round(durations.quantile(0.95), 1)
-                    if len(durations) > 0
-                    else 0
+                    round(durations.quantile(0.95), 1) if len(durations) > 0 else 0
                 ),
                 "error_count": error_count,
-                "error_rate": (
-                    round(error_count / total, 3) if total > 0 else 0
-                ),
+                "error_rate": (round(error_count / total, 3) if total > 0 else 0),
             }
         )
 

--- a/src/mlflow_client/client.py
+++ b/src/mlflow_client/client.py
@@ -32,9 +32,7 @@ class MLflowAnalystClient:
 
     def __init__(self, tracking_uri: str | None = None) -> None:
         self._tracking_uri: str = (
-            tracking_uri
-            or os.getenv("MLFLOW_TRACKING_URI")
-            or "http://localhost:5000"
+            tracking_uri or os.getenv("MLFLOW_TRACKING_URI") or "http://localhost:5000"
         )
         mlflow.set_tracking_uri(self._tracking_uri)
         self._client = mlflow.MlflowClient(tracking_uri=self._tracking_uri)
@@ -130,13 +128,10 @@ class MLflowAnalystClient:
             ]
         except MlflowException as exc:
             raise MLflowClientError(
-                f"Could not list runs for experiment '{experiment_id}'. "
-                f"MLflow error: {exc}"
+                f"Could not list runs for experiment '{experiment_id}'. MLflow error: {exc}"
             ) from exc
         except Exception as exc:
-            raise MLflowClientError(
-                f"Unexpected error listing runs: {exc}"
-            ) from exc
+            raise MLflowClientError(f"Unexpected error listing runs: {exc}") from exc
 
     def get_run_details(self, run_id: str) -> RunDetails:
         """Fetch full details of a run including params, metrics, and tags.
@@ -154,13 +149,10 @@ class MLflowAnalystClient:
             run = self._client.get_run(run_id)
         except MlflowException as exc:
             raise MLflowClientError(
-                f"Run '{run_id}' not found. Verify the run ID is correct. "
-                f"Details: {exc}"
+                f"Run '{run_id}' not found. Verify the run ID is correct. Details: {exc}"
             ) from exc
         except Exception as exc:
-            raise MLflowClientError(
-                f"Could not fetch run '{run_id}': {exc}"
-            ) from exc
+            raise MLflowClientError(f"Could not fetch run '{run_id}': {exc}") from exc
 
         metrics = {k: float(v) for k, v in run.data.metrics.items()}
         if not metrics:
@@ -213,6 +205,7 @@ class MLflowAnalystClient:
 
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
+
 
 def _ms_to_dt(ms: int | None) -> datetime | None:
     """Convert millisecond timestamp to UTC datetime."""

--- a/src/observability/governance.py
+++ b/src/observability/governance.py
@@ -59,6 +59,7 @@ class GovernanceCallbackHandler(BaseCallbackHandler):
         self.max_consecutive_failures = max_consecutive_failures
 
         self._tool_start_times: dict[str, float] = {}
+        self._chain_start_times: dict[str, float] = {}
         self._total_tokens: int = 0
         self._consecutive_failures: int = 0
 
@@ -79,7 +80,7 @@ class GovernanceCallbackHandler(BaseCallbackHandler):
         self._tool_start_times[call_id] = time.monotonic()
         self._write_event(
             event_type="tool_start",
-            tool_name=serialized.get("name", "unknown"),
+            tool_name=(serialized.get("name", "unknown") if serialized else "unknown"),
             input_summary=_truncate(input_str, 200),
         )
 
@@ -92,9 +93,7 @@ class GovernanceCallbackHandler(BaseCallbackHandler):
     ) -> None:
         call_id = str(run_id) if run_id else ""
         start = self._tool_start_times.pop(call_id, None)
-        duration_ms = (
-            round((time.monotonic() - start) * 1000, 1) if start else None
-        )
+        duration_ms = round((time.monotonic() - start) * 1000, 1) if start else None
         self._consecutive_failures = 0
         self._write_event(
             event_type="tool_end",
@@ -116,8 +115,7 @@ class GovernanceCallbackHandler(BaseCallbackHandler):
         )
         if self._consecutive_failures >= self.max_consecutive_failures:
             raise GovernanceLimitError(
-                f"Consecutive tool failures reached limit "
-                f"({self.max_consecutive_failures})"
+                f"Consecutive tool failures reached limit ({self.max_consecutive_failures})"
             )
 
     # ─── LLM hooks ──────────────────────────────────────────────────────────
@@ -145,29 +143,41 @@ class GovernanceCallbackHandler(BaseCallbackHandler):
 
     def on_chain_start(
         self,
-        serialized: dict[str, Any],
-        inputs: dict[str, Any],
+        serialized: dict[str, Any] | None,
+        inputs: dict[str, Any] | None,
         *,
         run_id: uuid.UUID | None = None,
         **kwargs: Any,
     ) -> None:
-        chain_name = serialized.get("id", ["unknown"])[-1]
+        call_id = str(run_id) if run_id else uuid.uuid4().hex
+        self._chain_start_times[call_id] = time.monotonic()
+        chain_name = "unknown"
+        if serialized and isinstance(serialized, dict):
+            ids = serialized.get("id")
+            if isinstance(ids, list) and ids:
+                chain_name = str(ids[-1])
+            else:
+                chain_name = serialized.get("name", "unknown")
         self._write_event(
             event_type="chain_start",
             tool_name=chain_name,
-            input_summary=_truncate(str(inputs), 200),
+            input_summary=_truncate(str(inputs or ""), 200),
         )
 
     def on_chain_end(
         self,
-        outputs: dict[str, Any],
+        outputs: dict[str, Any] | None,
         *,
         run_id: uuid.UUID | None = None,
         **kwargs: Any,
     ) -> None:
+        call_id = str(run_id) if run_id else ""
+        start = self._chain_start_times.pop(call_id, None)
+        duration_ms = round((time.monotonic() - start) * 1000, 1) if start else None
         self._write_event(
             event_type="chain_end",
-            output_summary=_truncate(str(outputs), 500),
+            output_summary=_truncate(str(outputs or ""), 500),
+            duration_ms=duration_ms,
         )
 
     # ─── Internal ────────────────────────────────────────────────────────────
@@ -221,13 +231,48 @@ def _truncate(text: str, max_len: int) -> str:
 
 
 def _extract_token_usage(response: LLMResult) -> dict[str, int] | None:
-    """Extract token usage from an LLMResult, if available."""
+    """Extract token usage from an LLMResult, if available.
+
+    Handles multiple formats:
+    - OpenAI-style: ``llm_output.token_usage.{prompt_tokens, completion_tokens, total_tokens}``
+    - Ollama-style: ``generation_info.{prompt_eval_count, eval_count}``
+    - LangChain usage_metadata on AIMessage: ``message.usage_metadata``
+    """
+    # 1) Try standard llm_output (OpenAI, Anthropic)
     llm_output = response.llm_output or {}
     usage = llm_output.get("token_usage") or llm_output.get("usage")
-    if not usage:
-        return None
-    return {
-        "prompt": usage.get("prompt_tokens", 0),
-        "completion": usage.get("completion_tokens", 0),
-        "total": usage.get("total_tokens", 0),
-    }
+    if usage:
+        return {
+            "prompt": usage.get("prompt_tokens", 0),
+            "completion": usage.get("completion_tokens", 0),
+            "total": usage.get("total_tokens", 0),
+        }
+
+    # 2) Try generation_info (Ollama puts counts here)
+    try:
+        gen_info = response.generations[0][0].generation_info or {}
+        prompt_tokens = gen_info.get("prompt_eval_count", 0)
+        completion_tokens = gen_info.get("eval_count", 0)
+        if prompt_tokens or completion_tokens:
+            return {
+                "prompt": prompt_tokens,
+                "completion": completion_tokens,
+                "total": prompt_tokens + completion_tokens,
+            }
+    except (IndexError, AttributeError):
+        pass
+
+    # 3) Try usage_metadata on the AIMessage (newer LangChain)
+    try:
+        message = response.generations[0][0].message
+        meta = getattr(message, "usage_metadata", None)
+        if meta and isinstance(meta, dict):
+            return {
+                "prompt": meta.get("input_tokens", 0),
+                "completion": meta.get("output_tokens", 0),
+                "total": meta.get("total_tokens", 0),
+            }
+    except (IndexError, AttributeError):
+        pass
+
+    return None

--- a/src/report/generator.py
+++ b/src/report/generator.py
@@ -54,8 +54,7 @@ def generate_markdown_report(
         df = compare_metrics(analysis.runs)
         if analysis.target_metric in df.columns:
             is_lower = any(
-                t in analysis.target_metric
-                for t in {"loss", "rmse", "mae", "mse", "error"}
+                t in analysis.target_metric for t in {"loss", "rmse", "mae", "mse", "error"}
             )
             df = rank_runs(df, analysis.target_metric, ascending=is_lower)
 
@@ -76,9 +75,7 @@ def generate_markdown_report(
                 worst = max(r.gaps, key=lambda g: g.gap, default=None)
                 gap_str = f"{worst.gap:.3f} ({worst.metric_base})" if worst else "—"
                 name = r.run_name or r.run_id
-                rows.append(
-                    f"| `{name}` | {icon} {r.severity.value} | {gap_str} | {r.message} |"
-                )
+                rows.append(f"| `{name}` | {icon} {r.severity.value} | {gap_str} | {r.message} |")
             sections.append("\n".join(rows))
         else:
             sections.append("✅ No overfitting detected in any analyzed run.")
@@ -94,9 +91,7 @@ def generate_markdown_report(
             "|---|---|---|---|",
         ]
         for p in report.top_params[:10]:
-            rows.append(
-                f"| `{p.param}` | {p.correlation:.3f} | {p.direction} | {p.n_runs} |"
-            )
+            rows.append(f"| `{p.param}` | {p.correlation:.3f} | {p.direction} | {p.n_runs} |")
         sections.append("\n".join(rows))
         sections.append(f"_{report.message}_")
     elif report:
@@ -133,6 +128,7 @@ def generate_markdown_report(
 
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
+
 
 def _df_to_markdown(df: pd.DataFrame) -> str:
     """Convert a DataFrame to a Markdown table string."""

--- a/src/tools/analyze_patterns.py
+++ b/src/tools/analyze_patterns.py
@@ -66,8 +66,7 @@ def analyze_patterns(
             f"Pattern analysis for experiment '{experiment_name}' "
             f"(target: `{target_metric}`):\n\n"
             f"ℹ️ {report.message}\n\n"
-            f"Runs fetched: {len(runs)}"
-            + (f" ({fetch_errors} failed)" if fetch_errors else "")
+            f"Runs fetched: {len(runs)}" + (f" ({fetch_errors} failed)" if fetch_errors else "")
         )
 
     lines = [
@@ -96,8 +95,10 @@ def analyze_patterns(
                 interpretation = f"Weak relationship with `{target_metric}`"
 
             strength = (
-                "strong" if abs(p.correlation) >= 0.7
-                else "moderate" if abs(p.correlation) >= 0.4
+                "strong"
+                if abs(p.correlation) >= 0.7
+                else "moderate"
+                if abs(p.correlation) >= 0.4
                 else "weak"
             )
             lines.append(
@@ -127,10 +128,7 @@ def analyze_patterns(
             + ", ".join(f"`{p.param}` (r={p.correlation:+.2f})" for p in negatives[:3])
         )
     if neutrals:
-        lines.append(
-            "**No clear effect:** "
-            + ", ".join(f"`{p.param}`" for p in neutrals[:5])
-        )
+        lines.append("**No clear effect:** " + ", ".join(f"`{p.param}`" for p in neutrals[:5]))
     if not positives and not negatives:
         lines.append(
             "No strong correlations found. Consider: more runs with varied hyperparameters, "

--- a/src/tools/generate_report.py
+++ b/src/tools/generate_report.py
@@ -14,9 +14,7 @@ from src.analysis.suggestions import AnalysisResult, suggest_next_experiments
 from src.mlflow_client.client import MLflowAnalystClient, MLflowClientError
 from src.report.generator import generate_markdown_report
 
-_DEFAULT_REPORTS_DIR = Path(
-    os.getenv("AGENT_WORKSPACE_PATH", "data/agent-workspace")
-) / "reports"
+_DEFAULT_REPORTS_DIR = Path(os.getenv("AGENT_WORKSPACE_PATH", "data/agent-workspace")) / "reports"
 
 
 @tool
@@ -54,10 +52,7 @@ def generate_report(
         return f"ERROR: Could not list runs for '{experiment_name}': {exc}"
 
     if not run_infos:
-        return (
-            f"Experiment '{experiment_name}' has no runs. "
-            "Cannot generate a report without data."
-        )
+        return f"Experiment '{experiment_name}' has no runs. Cannot generate a report without data."
 
     runs = []
     fetch_errors = 0

--- a/src/tools/suggest_next_experiments.py
+++ b/src/tools/suggest_next_experiments.py
@@ -129,6 +129,7 @@ def suggest_next_experiments(
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
+
 def _extract_metric_from_goal(optimization_goal: str, runs: list) -> str:
     """Infer the target metric name from the optimization goal string.
 

--- a/tests/edge_cases/test_edge_analysis.py
+++ b/tests/edge_cases/test_edge_analysis.py
@@ -67,9 +67,7 @@ def test_metric_delta_identical_runs() -> None:
 
 
 def test_overfitting_extreme_gap() -> None:
-    run = _make_run(
-        "r1", {"train_accuracy": 1.0, "val_accuracy": 0.0}
-    )
+    run = _make_run("r1", {"train_accuracy": 1.0, "val_accuracy": 0.0})
     report = detect_overfitting(run)
     assert report.is_overfit is True
     assert report.severity == OverfitSeverity.HIGH
@@ -77,9 +75,7 @@ def test_overfitting_extreme_gap() -> None:
 
 def test_overfitting_negative_gap() -> None:
     # Val better than train — not overfitting
-    run = _make_run(
-        "r1", {"train_accuracy": 0.80, "val_accuracy": 0.85}
-    )
+    run = _make_run("r1", {"train_accuracy": 0.80, "val_accuracy": 0.85})
     report = detect_overfitting(run)
     assert report.is_overfit is False
 

--- a/tests/edge_cases/test_edge_tools.py
+++ b/tests/edge_cases/test_edge_tools.py
@@ -50,17 +50,13 @@ def _make_run(
 
 def test_load_experiment_zero_runs() -> None:
     with (
-        patch.object(
-            _load_experiment_mod, "MLflowAnalystClient"
-        ) as mock_cls,
+        patch.object(_load_experiment_mod, "MLflowAnalystClient") as mock_cls,
     ):
         client = mock_cls.return_value
         client.get_experiment.return_value = _make_experiment()
         client.list_runs.return_value = []
 
-        result = _load_experiment_mod.load_experiment.invoke(
-            {"experiment_name": "edge-exp"}
-        )
+        result = _load_experiment_mod.load_experiment.invoke({"experiment_name": "edge-exp"})
         assert "0 run" in result.lower() or "no runs" in result.lower() or "0" in result
 
 
@@ -85,15 +81,15 @@ def test_suggest_single_run() -> None:
         client.get_experiment.return_value = _make_experiment()
         client.list_runs.return_value = [
             RunInfo(
-                run_id="run-001", experiment_id="1", run_name="r1",
+                run_id="run-001",
+                experiment_id="1",
+                run_name="r1",
                 status="FINISHED",
             )
         ]
         client.get_run_details.return_value = _make_run()
 
-        result = _suggest_mod.suggest_next_experiments.invoke(
-            {"experiment_name": "edge-exp"}
-        )
+        result = _suggest_mod.suggest_next_experiments.invoke({"experiment_name": "edge-exp"})
         assert isinstance(result, str)
         assert "ERROR" not in result
 
@@ -123,8 +119,10 @@ def test_analyze_patterns_non_numeric_params() -> None:
         client.get_experiment.return_value = _make_experiment()
         client.list_runs.return_value = [
             RunInfo(
-                run_id=r.run_id, experiment_id="1",
-                run_name=r.run_name, status="FINISHED",
+                run_id=r.run_id,
+                experiment_id="1",
+                run_name=r.run_name,
+                status="FINISHED",
             )
             for r in runs
         ]
@@ -145,8 +143,10 @@ def test_generate_report_no_target_metric() -> None:
         client.get_experiment.return_value = _make_experiment()
         client.list_runs.return_value = [
             RunInfo(
-                run_id="r1", experiment_id="1",
-                run_name="run-1", status="FINISHED",
+                run_id="r1",
+                experiment_id="1",
+                run_name="run-1",
+                status="FINISHED",
             )
         ]
         client.get_run_details.return_value = runs[0]
@@ -164,21 +164,15 @@ def test_generate_report_no_target_metric() -> None:
 
 def test_load_experiment_connection_error() -> None:
     with patch.object(_load_experiment_mod, "MLflowAnalystClient") as mock_cls:
-        mock_cls.return_value.get_experiment.side_effect = MLflowClientError(
-            "Connection refused"
-        )
+        mock_cls.return_value.get_experiment.side_effect = MLflowClientError("Connection refused")
 
-        result = _load_experiment_mod.load_experiment.invoke(
-            {"experiment_name": "edge-exp"}
-        )
+        result = _load_experiment_mod.load_experiment.invoke({"experiment_name": "edge-exp"})
         assert "ERROR" in result
 
 
 def test_compare_runs_run_not_found() -> None:
     with patch.object(_compare_runs_mod, "MLflowAnalystClient") as mock_cls:
-        mock_cls.return_value.get_run_details.side_effect = MLflowClientError(
-            "Run not found"
-        )
+        mock_cls.return_value.get_run_details.side_effect = MLflowClientError("Run not found")
 
         result = _compare_runs_mod.compare_runs.invoke(
             {"run_ids": ["bad-id"], "experiment_name": "edge-exp"}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -59,9 +59,7 @@ def seeded_experiment(mlflow_available: bool):  # type: ignore[no-untyped-def]
     run_ids: list[str] = []
     for i in range(3):
         with mlflow.start_run(experiment_id=exp_id, run_name=f"run-{i}") as run:
-            mlflow.log_params(
-                {"learning_rate": str(0.01 * (i + 1)), "epochs": "10"}
-            )
+            mlflow.log_params({"learning_rate": str(0.01 * (i + 1)), "epochs": "10"})
             mlflow.log_metrics(
                 {
                     "train_accuracy": 0.90 + i * 0.02,

--- a/tests/integration/test_agent_e2e.py
+++ b/tests/integration/test_agent_e2e.py
@@ -15,7 +15,8 @@ pytestmark = pytest.mark.integration
 
 
 def test_mlflow_client_get_experiment(
-    mlflow_client, seeded_experiment  # type: ignore[no-untyped-def]
+    mlflow_client,
+    seeded_experiment,  # type: ignore[no-untyped-def]
 ) -> None:
     exp_name, exp_id, _ = seeded_experiment
     exp = mlflow_client.get_experiment(exp_name)
@@ -24,7 +25,8 @@ def test_mlflow_client_get_experiment(
 
 
 def test_mlflow_client_list_runs(
-    mlflow_client, seeded_experiment  # type: ignore[no-untyped-def]
+    mlflow_client,
+    seeded_experiment,  # type: ignore[no-untyped-def]
 ) -> None:
     _, exp_id, run_ids = seeded_experiment
     runs = mlflow_client.list_runs(exp_id)
@@ -34,7 +36,8 @@ def test_mlflow_client_list_runs(
 
 
 def test_load_experiment_tool_e2e(
-    mlflow_available, seeded_experiment  # type: ignore[no-untyped-def]
+    mlflow_available,
+    seeded_experiment,  # type: ignore[no-untyped-def]
 ) -> None:
     exp_name, _, _ = seeded_experiment
     mod = importlib.import_module("src.tools.load_experiment")
@@ -44,19 +47,20 @@ def test_load_experiment_tool_e2e(
 
 
 def test_compare_runs_tool_e2e(
-    mlflow_available, seeded_experiment  # type: ignore[no-untyped-def]
+    mlflow_available,
+    seeded_experiment,  # type: ignore[no-untyped-def]
 ) -> None:
     exp_name, _, run_ids = seeded_experiment
     mod = importlib.import_module("src.tools.compare_runs")
-    result = mod.compare_runs.invoke(
-        {"run_ids": run_ids[:2], "experiment_name": exp_name}
-    )
+    result = mod.compare_runs.invoke({"run_ids": run_ids[:2], "experiment_name": exp_name})
     assert "val_accuracy" in result
     assert "ERROR" not in result
 
 
 def test_generate_report_tool_e2e(
-    mlflow_available, seeded_experiment, tmp_path  # type: ignore[no-untyped-def]
+    mlflow_available,
+    seeded_experiment,
+    tmp_path,  # type: ignore[no-untyped-def]
 ) -> None:
     exp_name, _, _ = seeded_experiment
     mod = importlib.import_module("src.tools.generate_report")

--- a/tests/unit/test_analysis.py
+++ b/tests/unit/test_analysis.py
@@ -16,6 +16,7 @@ from src.mlflow_client.models import RunDetails
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
+
 def _run(
     run_id: str,
     metrics: dict,
@@ -33,6 +34,7 @@ def _run(
 
 
 # ─── metrics.py ───────────────────────────────────────────────────────────────
+
 
 class TestCompareMetrics:
     def test_returns_dataframe_with_all_metrics(self) -> None:
@@ -97,6 +99,7 @@ class TestMetricDelta:
 
 # ─── overfitting.py ───────────────────────────────────────────────────────────
 
+
 class TestDetectOverfitting:
     def test_detects_high_overfit(self) -> None:
         run = _run("a", {"train_accuracy": 0.99, "val_accuracy": 0.55})
@@ -128,8 +131,9 @@ class TestDetectOverfitting:
         assert report.is_overfit
 
     def test_affected_metrics_populated(self) -> None:
-        run = _run("a", {"train_accuracy": 0.99, "val_accuracy": 0.60,
-                          "train_f1": 0.98, "val_f1": 0.59})
+        run = _run(
+            "a", {"train_accuracy": 0.99, "val_accuracy": 0.60, "train_f1": 0.98, "val_f1": 0.59}
+        )
         report = detect_overfitting(run)
         assert len(report.affected_metrics) > 0
 
@@ -150,6 +154,7 @@ class TestDetectOverfittingTrend:
 
 
 # ─── patterns.py ──────────────────────────────────────────────────────────────
+
 
 class TestCorrelateParamsMetrics:
     def test_finds_positive_correlation(self) -> None:
@@ -193,6 +198,7 @@ class TestCorrelateParamsMetrics:
 
 
 # ─── suggestions.py ───────────────────────────────────────────────────────────
+
 
 class TestSuggestNextExperiments:
     def test_returns_suggestions(self) -> None:

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -76,9 +76,7 @@ def test_load_system_prompt_fallback() -> None:
     with patch("src.agent.builder.Path") as mock_path_cls:
         mock_file = MagicMock()
         mock_file.parent.__truediv__ = MagicMock(
-            return_value=MagicMock(
-                __truediv__=MagicMock(return_value=fake_prompt_path)
-            )
+            return_value=MagicMock(__truediv__=MagicMock(return_value=fake_prompt_path))
         )
         mock_path_cls.return_value = mock_file
 
@@ -154,9 +152,7 @@ def test_create_analyst_agent_with_hitl_tools(tmp_path: Path) -> None:
             llm_provider="ollama",
             workspace_path=tmp_path / "ws",
         )
-        builder_mod.create_analyst_agent(
-            config, hitl_tools=["generate_report"]
-        )
+        builder_mod.create_analyst_agent(config, hitl_tools=["generate_report"])
 
         call_kwargs = mock_create.call_args
         interrupt_on = call_kwargs.kwargs.get("interrupt_on")
@@ -182,9 +178,7 @@ def test_invoke_with_governance_attaches_callback(tmp_path: Path) -> None:
     call_args = mock_agent.invoke.call_args
     invoke_config = call_args[0][1] if len(call_args[0]) > 1 else call_args[1]
     callbacks = invoke_config.get("callbacks", [])
-    assert any(
-        isinstance(cb, GovernanceCallbackHandler) for cb in callbacks
-    )
+    assert any(isinstance(cb, GovernanceCallbackHandler) for cb in callbacks)
 
 
 def test_invoke_with_governance_timeout(tmp_path: Path) -> None:

--- a/tests/unit/test_governance.py
+++ b/tests/unit/test_governance.py
@@ -45,9 +45,7 @@ def _read_events(log_path: Path) -> list[dict]:
 # ─── on_tool_start ───────────────────────────────────────────────────────────
 
 
-def test_on_tool_start_creates_log_file(
-    handler: GovernanceCallbackHandler, tmp_path: Path
-) -> None:
+def test_on_tool_start_creates_log_file(handler: GovernanceCallbackHandler, tmp_path: Path) -> None:
     handler.on_tool_start(
         {"name": "load_experiment"},
         '{"experiment_name": "test"}',
@@ -63,9 +61,7 @@ def test_on_tool_start_creates_log_file(
 # ─── on_tool_end ─────────────────────────────────────────────────────────────
 
 
-def test_on_tool_end_logs_duration(
-    handler: GovernanceCallbackHandler, tmp_path: Path
-) -> None:
+def test_on_tool_end_logs_duration(handler: GovernanceCallbackHandler, tmp_path: Path) -> None:
     rid = uuid.uuid4()
     handler.on_tool_start({"name": "compare_runs"}, "{}", run_id=rid)
     handler.on_tool_end("Results: ...", run_id=rid)
@@ -156,9 +152,7 @@ def test_successful_tool_resets_failure_count(
 def test_log_entry_schema_has_all_fields(
     handler: GovernanceCallbackHandler, tmp_path: Path
 ) -> None:
-    handler.on_tool_start(
-        {"name": "diagnose_run"}, '{"run_id": "abc"}', run_id=uuid.uuid4()
-    )
+    handler.on_tool_start({"name": "diagnose_run"}, '{"run_id": "abc"}', run_id=uuid.uuid4())
 
     log_file = _find_log_file(tmp_path)
     events = _read_events(log_file)

--- a/tests/unit/test_mlflow_client.py
+++ b/tests/unit/test_mlflow_client.py
@@ -14,10 +14,13 @@ from src.mlflow_client.models import RunDetails
 
 # ─── Fixtures ─────────────────────────────────────────────────────────────────
 
+
 @pytest.fixture()
 def client() -> MLflowAnalystClient:
-    with patch("src.mlflow_client.client.mlflow"), \
-         patch("src.mlflow_client.client.mlflow.MlflowClient"):
+    with (
+        patch("src.mlflow_client.client.mlflow"),
+        patch("src.mlflow_client.client.mlflow.MlflowClient"),
+    ):
         c = MLflowAnalystClient(tracking_uri="http://fake:5000")
     return c
 
@@ -45,6 +48,7 @@ def _mock_run(
 
 
 # ─── get_experiment ────────────────────────────────────────────────────────────
+
 
 def test_get_experiment_by_name(client: MLflowAnalystClient) -> None:
     mock_exp = MagicMock()
@@ -74,6 +78,7 @@ def test_get_experiment_not_found_raises(client: MLflowAnalystClient) -> None:
 
 # ─── list_runs ────────────────────────────────────────────────────────────────
 
+
 def test_list_runs_returns_run_info(client: MLflowAnalystClient) -> None:
     mock_run = _mock_run()
 
@@ -93,6 +98,7 @@ def test_list_runs_empty(client: MLflowAnalystClient) -> None:
 
 
 # ─── get_run_details ──────────────────────────────────────────────────────────
+
 
 def test_get_run_details_returns_full_data(client: MLflowAnalystClient) -> None:
     mock_run = _mock_run()
@@ -125,16 +131,25 @@ def test_get_run_details_not_found_raises(client: MLflowAnalystClient) -> None:
 
 # ─── compare_runs ─────────────────────────────────────────────────────────────
 
+
 def test_compare_runs_returns_dataframe(client: MLflowAnalystClient) -> None:
     import pandas as pd
 
     run_a = RunDetails(
-        run_id="a", experiment_id="1", run_name="run-a", status="FINISHED",
-        params={"lr": "0.01"}, metrics={"val_accuracy": 0.90},
+        run_id="a",
+        experiment_id="1",
+        run_name="run-a",
+        status="FINISHED",
+        params={"lr": "0.01"},
+        metrics={"val_accuracy": 0.90},
     )
     run_b = RunDetails(
-        run_id="b", experiment_id="1", run_name="run-b", status="FINISHED",
-        params={"lr": "0.001"}, metrics={"val_accuracy": 0.85},
+        run_id="b",
+        experiment_id="1",
+        run_name="run-b",
+        status="FINISHED",
+        params={"lr": "0.001"},
+        metrics={"val_accuracy": 0.85},
     )
 
     client.get_run_details = MagicMock(side_effect=[run_a, run_b])
@@ -170,12 +185,20 @@ def test_compare_runs_partial_metrics(client: MLflowAnalystClient) -> None:
     import pandas as pd
 
     run_a = RunDetails(
-        run_id="a", experiment_id="1", run_name="run-a", status="FINISHED",
-        params={}, metrics={"val_accuracy": 0.9, "val_loss": 0.1},
+        run_id="a",
+        experiment_id="1",
+        run_name="run-a",
+        status="FINISHED",
+        params={},
+        metrics={"val_accuracy": 0.9, "val_loss": 0.1},
     )
     run_b = RunDetails(
-        run_id="b", experiment_id="1", run_name="run-b", status="FINISHED",
-        params={}, metrics={"val_accuracy": 0.8},  # no val_loss
+        run_id="b",
+        experiment_id="1",
+        run_name="run-b",
+        status="FINISHED",
+        params={},
+        metrics={"val_accuracy": 0.8},  # no val_loss
     )
 
     client.get_run_details = MagicMock(side_effect=[run_a, run_b])

--- a/tests/unit/test_report_generator.py
+++ b/tests/unit/test_report_generator.py
@@ -46,9 +46,7 @@ def _make_analysis(
 
 
 def test_report_contains_header() -> None:
-    analysis = _make_analysis(
-        runs=[_make_run("r1", "run-1", {"val_accuracy": 0.9})]
-    )
+    analysis = _make_analysis(runs=[_make_run("r1", "run-1", {"val_accuracy": 0.9})])
     report = generate_markdown_report(analysis)
     assert "# Analysis Report: test-experiment" in report
     assert "**Runs analyzed:** 1" in report
@@ -128,15 +126,11 @@ def test_patterns_with_correlations() -> None:
         experiment_id="exp-1",
         n_runs=10,
         correlations=[
-            ParamCorrelation(
-                param="lr", correlation=0.85, direction="positive", n_runs=10
-            ),
+            ParamCorrelation(param="lr", correlation=0.85, direction="positive", n_runs=10),
         ],
         message="Strong positive correlation found",
     )
-    report = generate_markdown_report(
-        _make_analysis(correlation_report=corr_report)
-    )
+    report = generate_markdown_report(_make_analysis(correlation_report=corr_report))
     assert "`lr`" in report
     assert "0.85" in report.replace("0.850", "0.85")
 
@@ -149,16 +143,12 @@ def test_patterns_no_correlations() -> None:
         correlations=[],
         message="Not enough runs for correlation analysis",
     )
-    report = generate_markdown_report(
-        _make_analysis(correlation_report=corr_report)
-    )
+    report = generate_markdown_report(_make_analysis(correlation_report=corr_report))
     assert "Not enough runs" in report
 
 
 def test_patterns_not_performed() -> None:
-    report = generate_markdown_report(
-        _make_analysis(correlation_report=None)
-    )
+    report = generate_markdown_report(_make_analysis(correlation_report=None))
     assert "_Pattern analysis not performed._" in report
 
 
@@ -180,9 +170,7 @@ def test_recommendations_with_suggestions() -> None:
             hypothesis="Better generalization",
         ),
     ]
-    report = generate_markdown_report(
-        _make_analysis(suggestions=suggestions)
-    )
+    report = generate_markdown_report(_make_analysis(suggestions=suggestions))
     assert "### 1." in report
     assert "### 2." in report
     assert "`lr=0.1`" in report
@@ -222,9 +210,7 @@ def test_df_to_markdown_empty() -> None:
 
 
 def test_df_to_markdown_rounds_floats() -> None:
-    df = pd.DataFrame(
-        {"val": [0.123456789]}, index=["run-1"]
-    )
+    df = pd.DataFrame({"val": [0.123456789]}, index=["run-1"])
     result = _df_to_markdown(df)
     assert "0.1235" in result
     assert "0.123456789" not in result

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -31,6 +31,7 @@ _generate_report_mod = importlib.import_module("src.tools.generate_report")
 
 # ─── Shared test data ─────────────────────────────────────────────────────────
 
+
 def _make_experiment(name: str = "test-exp", exp_id: str = "1") -> ExperimentInfo:
     return ExperimentInfo(
         experiment_id=exp_id,
@@ -53,7 +54,8 @@ def _make_run(
         run_name=run_name,
         status=status,
         params=params or {"learning_rate": "0.01", "n_estimators": "100"},
-        metrics=metrics or {
+        metrics=metrics
+        or {
             "train_accuracy": 0.95,
             "val_accuracy": 0.88,
             "train_loss": 0.12,
@@ -72,6 +74,7 @@ def _make_run_info(run_id: str = "run-001", run_name: str = "test-run") -> RunIn
 
 
 # ─── load_experiment ──────────────────────────────────────────────────────────
+
 
 class TestLoadExperiment:
     def test_happy_path(self):
@@ -133,6 +136,7 @@ class TestLoadExperiment:
 
 # ─── compare_runs ─────────────────────────────────────────────────────────────
 
+
 class TestCompareRuns:
     def test_happy_path(self):
         from src.tools.compare_runs import compare_runs
@@ -179,26 +183,31 @@ class TestCompareRuns:
             instance = MockClient.return_value
             instance.get_run_details.return_value = run
 
-            result = compare_runs.invoke({
-                "run_ids": ["run-001"],
-                "metrics_to_compare": ["val_accuracy"],
-            })
+            result = compare_runs.invoke(
+                {
+                    "run_ids": ["run-001"],
+                    "metrics_to_compare": ["val_accuracy"],
+                }
+            )
 
         assert "val_accuracy" in result
 
 
 # ─── diagnose_run ─────────────────────────────────────────────────────────────
 
+
 class TestDiagnoseRun:
     def test_healthy_run(self):
         from src.tools.diagnose_run import diagnose_run
 
-        run = _make_run(metrics={
-            "train_accuracy": 0.90,
-            "val_accuracy": 0.88,
-            "train_loss": 0.15,
-            "val_loss": 0.17,
-        })
+        run = _make_run(
+            metrics={
+                "train_accuracy": 0.90,
+                "val_accuracy": 0.88,
+                "train_loss": 0.15,
+                "val_loss": 0.17,
+            }
+        )
 
         with patch.object(_diagnose_run_mod, "MLflowAnalystClient") as MockClient:
             instance = MockClient.return_value
@@ -212,10 +221,12 @@ class TestDiagnoseRun:
     def test_overfitting_detected(self):
         from src.tools.diagnose_run import diagnose_run
 
-        overfit_run = _make_run(metrics={
-            "train_accuracy": 0.98,
-            "val_accuracy": 0.62,  # large gap → overfitting
-        })
+        overfit_run = _make_run(
+            metrics={
+                "train_accuracy": 0.98,
+                "val_accuracy": 0.62,  # large gap → overfitting
+            }
+        )
 
         with patch.object(_diagnose_run_mod, "MLflowAnalystClient") as MockClient:
             instance = MockClient.return_value
@@ -267,6 +278,7 @@ class TestDiagnoseRun:
 
 # ─── analyze_patterns ─────────────────────────────────────────────────────────
 
+
 class TestAnalyzePatterns:
     def _make_diverse_runs(self) -> list[RunDetails]:
         configs = [
@@ -300,10 +312,12 @@ class TestAnalyzePatterns:
             instance.list_runs.return_value = run_infos
             instance.get_run_details.side_effect = runs
 
-            result = analyze_patterns.invoke({
-                "experiment_name": "test-exp",
-                "target_metric": "val_accuracy",
-            })
+            result = analyze_patterns.invoke(
+                {
+                    "experiment_name": "test-exp",
+                    "target_metric": "val_accuracy",
+                }
+            )
 
         assert "val_accuracy" in result
         assert "ERROR" not in result
@@ -316,10 +330,12 @@ class TestAnalyzePatterns:
             instance = MockClient.return_value
             instance.get_experiment.side_effect = MLflowClientError("Not found.")
 
-            result = analyze_patterns.invoke({
-                "experiment_name": "missing",
-                "target_metric": "val_accuracy",
-            })
+            result = analyze_patterns.invoke(
+                {
+                    "experiment_name": "missing",
+                    "target_metric": "val_accuracy",
+                }
+            )
 
         assert "ERROR" in result
 
@@ -335,11 +351,13 @@ class TestAnalyzePatterns:
             instance.list_runs.return_value = run_infos
             instance.get_run_details.return_value = run_details
 
-            result = analyze_patterns.invoke({
-                "experiment_name": "test-exp",
-                "target_metric": "val_accuracy",
-                "min_runs": 5,
-            })
+            result = analyze_patterns.invoke(
+                {
+                    "experiment_name": "test-exp",
+                    "target_metric": "val_accuracy",
+                    "min_runs": 5,
+                }
+            )
 
         assert isinstance(result, str)
         assert len(result) > 0
@@ -347,13 +365,15 @@ class TestAnalyzePatterns:
 
 # ─── suggest_next_experiments ─────────────────────────────────────────────────
 
+
 class TestSuggestNextExperiments:
     def test_happy_path(self):
         from src.tools.suggest_next_experiments import suggest_next_experiments
 
         runs = [
             _make_run(
-                f"r{i}", f"run-{i}",
+                f"r{i}",
+                f"run-{i}",
                 params={
                     "learning_rate": str(0.001 * (i + 1)),
                     "n_estimators": str(50 * (i + 1)),
@@ -370,11 +390,13 @@ class TestSuggestNextExperiments:
             instance.list_runs.return_value = run_infos
             instance.get_run_details.side_effect = runs
 
-            result = suggest_next_experiments.invoke({
-                "experiment_name": "test-exp",
-                "optimization_goal": "maximize val_accuracy",
-                "num_suggestions": 3,
-            })
+            result = suggest_next_experiments.invoke(
+                {
+                    "experiment_name": "test-exp",
+                    "optimization_goal": "maximize val_accuracy",
+                    "num_suggestions": 3,
+                }
+            )
 
         assert "Suggestion" in result
         assert "ERROR" not in result
@@ -387,20 +409,19 @@ class TestSuggestNextExperiments:
             instance.get_experiment.return_value = _make_experiment()
             instance.list_runs.return_value = []
 
-            result = suggest_next_experiments.invoke({
-                "experiment_name": "test-exp",
-                "optimization_goal": "maximize val_accuracy",
-            })
+            result = suggest_next_experiments.invoke(
+                {
+                    "experiment_name": "test-exp",
+                    "optimization_goal": "maximize val_accuracy",
+                }
+            )
 
         assert "no runs" in result.lower() or "Run at least" in result
 
     def test_num_suggestions_capped_at_5(self):
         from src.tools.suggest_next_experiments import suggest_next_experiments
 
-        runs = [
-            _make_run(f"r{i}", metrics={"val_accuracy": 0.80 + i * 0.01})
-            for i in range(3)
-        ]
+        runs = [_make_run(f"r{i}", metrics={"val_accuracy": 0.80 + i * 0.01}) for i in range(3)]
         run_infos = [_make_run_info(r.run_id) for r in runs]
 
         with patch.object(_suggest_mod, "MLflowAnalystClient") as MockClient:
@@ -409,25 +430,31 @@ class TestSuggestNextExperiments:
             instance.list_runs.return_value = run_infos
             instance.get_run_details.side_effect = runs
 
-            result = suggest_next_experiments.invoke({
-                "experiment_name": "test-exp",
-                "optimization_goal": "maximize val_accuracy",
-                "num_suggestions": 10,
-            })
+            result = suggest_next_experiments.invoke(
+                {
+                    "experiment_name": "test-exp",
+                    "optimization_goal": "maximize val_accuracy",
+                    "num_suggestions": 10,
+                }
+            )
 
         assert isinstance(result, str)
 
 
 # ─── generate_report ──────────────────────────────────────────────────────────
 
+
 class TestGenerateReport:
     def test_happy_path(self, tmp_path: Path):
         from src.tools.generate_report import generate_report
 
         runs = [
-            _make_run(f"r{i}", f"run-{i}",
-                      params={"learning_rate": str(0.01 * (i + 1))},
-                      metrics={"train_accuracy": 0.9 + i * 0.01, "val_accuracy": 0.85 + i * 0.01})
+            _make_run(
+                f"r{i}",
+                f"run-{i}",
+                params={"learning_rate": str(0.01 * (i + 1))},
+                metrics={"train_accuracy": 0.9 + i * 0.01, "val_accuracy": 0.85 + i * 0.01},
+            )
             for i in range(3)
         ]
         run_infos = [_make_run_info(r.run_id) for r in runs]
@@ -439,11 +466,13 @@ class TestGenerateReport:
             instance.list_runs.return_value = run_infos
             instance.get_run_details.side_effect = runs
 
-            result = generate_report.invoke({
-                "experiment_name": "test-exp",
-                "report_title": "My Test Report",
-                "output_path": str(output_file),
-            })
+            result = generate_report.invoke(
+                {
+                    "experiment_name": "test-exp",
+                    "report_title": "My Test Report",
+                    "output_path": str(output_file),
+                }
+            )
 
         assert "Report saved" in result
         assert output_file.exists()
@@ -458,10 +487,12 @@ class TestGenerateReport:
             instance.get_experiment.return_value = _make_experiment()
             instance.list_runs.return_value = []
 
-            result = generate_report.invoke({
-                "experiment_name": "test-exp",
-                "report_title": "Empty Report",
-            })
+            result = generate_report.invoke(
+                {
+                    "experiment_name": "test-exp",
+                    "report_title": "Empty Report",
+                }
+            )
 
         assert "no runs" in result.lower() or "Cannot generate" in result
 
@@ -473,10 +504,12 @@ class TestGenerateReport:
             instance = MockClient.return_value
             instance.get_experiment.side_effect = MLflowClientError("Not found.")
 
-            result = generate_report.invoke({
-                "experiment_name": "missing-exp",
-                "report_title": "Report",
-            })
+            result = generate_report.invoke(
+                {
+                    "experiment_name": "missing-exp",
+                    "report_title": "Report",
+                }
+            )
 
         assert "ERROR" in result
 
@@ -484,10 +517,13 @@ class TestGenerateReport:
         from src.tools.generate_report import generate_report
 
         runs = [
-            _make_run(f"r{i}", metrics={
-                "train_accuracy": 0.95,
-                "val_accuracy": 0.60,  # overfitting
-            })
+            _make_run(
+                f"r{i}",
+                metrics={
+                    "train_accuracy": 0.95,
+                    "val_accuracy": 0.60,  # overfitting
+                },
+            )
             for i in range(3)
         ]
         run_infos = [_make_run_info(r.run_id) for r in runs]
@@ -499,11 +535,13 @@ class TestGenerateReport:
             instance.list_runs.return_value = run_infos
             instance.get_run_details.side_effect = runs
 
-            generate_report.invoke({
-                "experiment_name": "test-exp",
-                "report_title": "Sections Test",
-                "output_path": str(output_file),
-            })
+            generate_report.invoke(
+                {
+                    "experiment_name": "test-exp",
+                    "report_title": "Sections Test",
+                    "output_path": str(output_file),
+                }
+            )
 
         content = output_file.read_text(encoding="utf-8")
         assert "Metrics Comparison" in content
@@ -512,6 +550,7 @@ class TestGenerateReport:
 
 
 # ─── tools __init__ ───────────────────────────────────────────────────────────
+
 
 class TestToolsInit:
     def test_all_tools_exported(self):

--- a/tests/unit/test_web_search.py
+++ b/tests/unit/test_web_search.py
@@ -45,9 +45,7 @@ def test_web_search_returns_formatted_results() -> None:
         patch.dict("os.environ", {"TAVILY_API_KEY": "test-key"}),
         patch.dict("sys.modules", {"tavily": MagicMock(TavilyClient=mock_tavily_cls)}),
     ):
-        result = _web_search_mod.web_search.invoke(
-            {"query": "gradient boosting overfitting"}
-        )
+        result = _web_search_mod.web_search.invoke({"query": "gradient boosting overfitting"})
 
     assert "Gradient Boosting Guide" in result
     assert "Overfitting Solutions" in result
@@ -83,9 +81,7 @@ def test_web_search_clamps_max_results() -> None:
         patch.dict("os.environ", {"TAVILY_API_KEY": "test-key"}),
         patch.dict("sys.modules", {"tavily": MagicMock(TavilyClient=mock_tavily_cls)}),
     ):
-        _web_search_mod.web_search.invoke(
-            {"query": "test", "max_results": 10}
-        )
+        _web_search_mod.web_search.invoke({"query": "test", "max_results": 10})
 
     # Should have been clamped to 5
     mock_client.search.assert_called_once_with("test", max_results=5)


### PR DESCRIPTION
## Summary
- Fix GovernanceCallbackHandler to correctly capture token usage from Ollama and newer LangChain formats
- Add chain-level duration tracking so the dashboard shows total execution time
- Guard `on_chain_start` against `None` values from LangGraph internal chains
- Add OpenAI as third LLM provider (`ollama`, `anthropic`, `openai`)
- Sort dashboard Run Explorer by most recent execution first
- Apply `ruff format` to fix CI lint failures across 25 files

## Test plan
- [x] `pytest tests/unit/test_governance.py` — 9/9 passed
- [x] `ruff check` and `ruff format --check` — clean
- [ ] Run `scripts/run_demo.py` with Ollama and verify dashboard shows tokens and duration
- [ ] Run `scripts/run_demo.py` with OpenAI (requires API credits) to confirm tool calling works
